### PR TITLE
Use preserved entityName because entityOwner may not belong to the new temporary session that Hibernate Audit creates in case original session is closed.

### DIFF
--- a/src/main/java/com/googlecode/hibernate/audit/synchronization/work/AbstractCollectionAuditWorkUnit.java
+++ b/src/main/java/com/googlecode/hibernate/audit/synchronization/work/AbstractCollectionAuditWorkUnit.java
@@ -42,10 +42,8 @@ public abstract class AbstractCollectionAuditWorkUnit extends AbstractAuditWorkU
 
     protected void processElement(Session session, AuditConfiguration auditConfiguration, Object entityOwner, Object element, Type elementType, String propertyName, long index,
             EntityAuditObject auditObject, AuditEvent auditEvent) {
-    	
-    	String entityName = session.getEntityName(entityOwner);
-    	
-        AuditTypeField auditField = HibernateAudit.getAuditField(session, auditConfiguration.getExtensionManager().getAuditableInformationProvider().getAuditTypeClassName(auditConfiguration.getMetadata(), entityName), propertyName);
+
+        AuditTypeField auditField = HibernateAudit.getAuditField(session, auditConfiguration.getExtensionManager().getAuditableInformationProvider().getAuditTypeClassName(auditConfiguration.getMetadata(), getEntityName()), propertyName);
         AuditObjectProperty property = null;
         
         if (elementType.isEntityType()) {


### PR DESCRIPTION
Starting from Hibernate 5.2.0.Final there is an issue with Hibernate Audit.

AuditProcess#doBeforeTransactionCompletion receives closed session and Hibernate Audit can't determine entity name based on the following code:
session.getEntityName(entityOwner);

Session is closed because the SessionImpl#close() doesn't check whether transaction is active while closing the session comparing to the EntityManagerImpl#close() which closes session only in case transaction is inactive. However, [the EntityManagerImpl has been deleted by Hibernate team in Hibernate 5.2.0.Final](https://github.com/hibernate/hibernate-orm/commit/774b805ce1bd01abde8f18c399ab49580b569263) in favor of SessionImpl.

